### PR TITLE
Altered 'run' rake task so that it echoes any STDOUT or STDERR output from the running application to the TTY that is running rake.

### DIFF
--- a/lib/hotcocoa/standard_rake_tasks.rb
+++ b/lib/hotcocoa/standard_rake_tasks.rb
@@ -12,7 +12,20 @@ end
 
 desc "Build and execute the application"
 task :run => [:build] do
-  `"./#{AppConfig.name}.app/Contents/MacOS/#{AppConfig.name.gsub(/ /, '')}"`
+  require 'open3'
+  Open3.popen3("./#{AppConfig.name}.app/Contents/MacOS/#{AppConfig.name.gsub(/ /, '')} 2>&1") do |stdin, stdout, stderr|
+    loop do
+      break if(stdout.closed?)
+      if IO.select([stdout], nil, nil, 0.1)
+        begin
+          print(stdout.readpartial(4096))
+        rescue EOFError
+          break
+        end
+        $stdout.flush
+      end
+    end
+  end
 end
 
 desc "Cleanup build files"


### PR DESCRIPTION
Hey Rich!
This patch is fairly small but makes it _much_ easier to debug applications when running them using 'rake run' because any exceptions and their respective stack traces will now be output to the TTY running rake.

Let me know if anything needs to be altered before this can go upstream.

Thanks!
-Aaron
