### PR TITLE
Fix for "uninitialized constant Segment" error

### DIFF
--- a/lib/hotcocoa/mappings/segmented_control.rb
+++ b/lib/hotcocoa/mappings/segmented_control.rb
@@ -81,7 +81,7 @@ HotCocoa::Mappings.map :segmented_control => :NSSegmentedControl do
     end
     
     def [](segment_number)
-      Segment.new(self, segment_number)
+      HotCocoa::SegmentedControlSegment.new(self, segment_number)
     end
     
     def select(segment_number)

--- a/lib/hotcocoa/mappings/segmented_control.rb
+++ b/lib/hotcocoa/mappings/segmented_control.rb
@@ -58,6 +58,14 @@ end
 
 HotCocoa::Mappings.map :segmented_control => :NSSegmentedControl do
   
+  constant :segment_style, {
+    :rounded          => NSSegmentStyleRounded,
+    :textured_rounded => NSSegmentStyleTexturedRounded,
+    :round_rect       => NSSegmentStyleRoundRect,
+    :capsule          => NSSegmentStyleCapsule,
+    :small_square     => NSSegmentStyleSmallSquare
+  }
+
   defaults :layout => {}, :frame => [0,0,0,0]
   
   def init_with_options(segmented_control, options)


### PR DESCRIPTION
If you create a segmented_control, and try to access one of the segments by index (e.g. control[0]), it currently raises an "uninitialized constant" error. This patch fixes the #[] method so it refers to the correct proxy class for the segments. Cheers!
