### PR TITLE
`gsub!': invalid byte sequence in UTF-8 (ArgumentError) - when creating a new hotcocoa app

### DIFF
--- a/lib/hotcocoa/template.rb
+++ b/lib/hotcocoa/template.rb
@@ -16,7 +16,9 @@ module HotCocoa
           FileUtils.mkdir_p File.join(directory, short_name)
         else
           File.open(File.join(directory, short_name), "w") do |out|
-            input =  File.read(file)
+            is_icon_file = File.extname(file)[1..-1] == "icns"
+            format = is_icon_file ?  "BINARY" : "UTF-8"            
+            input =  File.open(file, "r:#{format}").read
             input.gsub!(/__APPLICATION_NAME__/, app_name)
             out.write input
           end


### PR DESCRIPTION
Hello, 

I tried on macruby 0.10

```
hotcocoa myapp
```

and i got this error:  

```
"`gsub!': invalid byte sequence in UTF-8 (ArgumentError)" 
```

I handled the case when reading icns icon file (binary)

hope this helps ! see you!
