### PR TITLE
Removed -arch i386 build flag

### DIFF
--- a/lib/hotcocoa/application_builder.rb
+++ b/lib/hotcocoa/application_builder.rb
@@ -218,7 +218,7 @@ module HotCocoa
             }
           }
         end
-        archs = RUBY_ARCH.include?('ppc') ? '-arch ppc' : '-arch i386 -arch x86_64'
+        archs = RUBY_ARCH.include?('ppc') ? '-arch ppc' : '-arch x86_64'
         puts `cd "#{macos_root}" && gcc main.m -o #{objective_c_executable_file} #{archs} -framework MacRuby -framework Foundation -fobjc-gc-only`
         File.unlink(objective_c_source_file)
       end


### PR DESCRIPTION
Hi,

I was unable to build and run HotCocoa apps.
So I removed the -arch i386 build flag from the build script.
I seems to be building and running again.
