### PR TITLE
Fixed link for Hotcocoa Repo

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 The official HotCocoa repository has moved. You can find it here:
 
-* http://github.com/ferrous26/hotcocoa
+* https://github.com/HotCocoa/hotcocoa
 
 == DESCRIPTION:
 


### PR DESCRIPTION
Updated the link to the active and non 404'ing hotcocoa repo. 
